### PR TITLE
Fix array

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const types = ['DEBUG', 'INFO', 'WARN', 'ERROR']
  * @param {Array} data Rest of pass arguments as array
  */
 types.forEach((type) => {
-  module.exports[type.toLowerCase()] = function(msg, ...data) {
+  module.exports[type.toLowerCase()] = function (msg, data = null) {
     const message = (msg instanceof Error) ? msg : JSON.stringify(msg)
     const epoch = Math.round(new Date().getTime() / 1000.0)
     const log = `${type} ${epoch} ${message} ${JSON.stringify(data)}`

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Console log wrapper to ensure consistent logs",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "./node_modules/.bin/ava test.js",
+    "lint": "./node_modules/.bin/standard index.js test.js"
   },
   "repository": {
     "type": "git",
@@ -15,5 +16,10 @@
   "bugs": {
     "url": "https://github.com/zesty-io/node-logger/issues"
   },
-  "homepage": "https://github.com/zesty-io/node-logger#readme"
+  "homepage": "https://github.com/zesty-io/node-logger#readme",
+  "devDependencies": {
+    "ava": "^0.16.0",
+    "intercept-stdout": "^0.1.2",
+    "standard": "^8.0.0-beta.5"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-logger",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Console log wrapper to ensure consistent logs",
   "main": "index.js",
   "scripts": {

--- a/test.js
+++ b/test.js
@@ -1,0 +1,53 @@
+'use strict'
+
+let test = require('ava')
+let log = require('./index')
+let intercept = require('intercept-stdout')
+
+test.beforeEach((t) => {
+  t.context.captured = ''
+  t.context.unhook = intercept((txt) => {
+    t.context.captured += txt
+  })
+})
+
+test.afterEach.always((t) => {
+  t.context.captured = ''
+  t.context.unhook()
+})
+
+test('log.info follows message pattern', (t) => {
+  log.info('log.info')
+  t.regex(t.context.captured, /INFO\s\d+\s"log.info"/)
+})
+
+test('log.info data is an object', (t) => {
+  log.info('log.info', {test: true})
+
+  // Extract logged data
+  let data = /(\{.*\})/.exec(t.context.captured)
+  let json = JSON.parse(data[0])
+
+  // Test logged object is an object
+  t.is(json.test, true)
+
+  // Should not be wrapped in an array
+  // this covers the legacy case where log
+  // wrapped everything in an array
+  t.is(Array.isArray(json), false)
+})
+
+test('log.debug follows message pattern', (t) => {
+  log.debug('log.debug')
+  t.regex(t.context.captured, /DEBUG\s\d+\s"log.debug"/)
+})
+
+test('log.warn follows message pattern', (t) => {
+  log.warn('log.warn')
+  t.regex(t.context.captured, /WARN\s\d+\s"log.warn"/)
+})
+
+test('log.error follows message pattern', (t) => {
+  log.error('log.error')
+  t.regex(t.context.captured, /ERROR\s\d+\s"log.error"/)
+})


### PR DESCRIPTION
Removing the rest operator in the function parameters. This was causing all vales being logged to be wrapped in an array. Very confusing seeing your object as an element of an array.

Now passing an object should log an object.

Included tests to verify
