### PR TITLE
Refactor to use factory function

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,22 +1,25 @@
 'use strict'
 
-const types = ['DEBUG', 'INFO', 'WARN', 'ERROR']
+module.exports = {
+  info: logFactory('INFO'),
+  debug: logFactory('DEBUG'),
+  warn: logFactory('WARN'),
+  error: logFactory('ERROR')
+}
 
-/**
- * Wrapper for console log levels
- *
- * @param {String} msg Main message to log
- * @param {Array} data Rest of pass arguments as array
- */
-types.forEach((type) => {
-  module.exports[type.toLowerCase()] = function (msg, data = null) {
-    const message = (msg instanceof Error) ? msg : JSON.stringify(msg)
+function logFactory(type) {
+  return function (message, data = null) {
     const epoch = Math.round(new Date().getTime() / 1000.0)
-    const log = `${type} ${epoch} ${message} ${JSON.stringify(data)}`
+    let log = {type, message, epoch, data}
+
+    if (process.env.NODE_ENV === 'production') {
+      log = JSON.stringify(log)
+    }
+
     if (type === 'ERROR') {
       console.error(log)
     } else {
       console.log(log)
     }
   }
-})
+}

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "node-logger",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Console log wrapper to ensure consistent logs",
   "main": "index.js",
   "scripts": {
-    "test": "./node_modules/.bin/ava test.js",
+    "test": "./node_modules/.bin/ava test/**/*spec.js",
     "lint": "./node_modules/.bin/standard index.js test.js"
   },
   "repository": {

--- a/test/helpers/parse-log.js
+++ b/test/helpers/parse-log.js
@@ -1,0 +1,8 @@
+'use strict'
+
+module.exports = function parseLog(log) {
+  let data = /(\{.*\})/.exec(log)
+  let json = JSON.parse(data[0])
+
+  return json
+}

--- a/test/production.spec.js
+++ b/test/production.spec.js
@@ -1,8 +1,11 @@
 'use strict'
 
 let test = require('ava')
-let log = require('./index')
 let intercept = require('intercept-stdout')
+let parse = require('./helpers/parse-log')
+let log = require('../index')
+
+process.env.NODE_ENV = 'production'
 
 test.beforeEach((t) => {
   t.context.captured = ''
@@ -18,36 +21,48 @@ test.afterEach.always((t) => {
 
 test('log.info follows message pattern', (t) => {
   log.info('log.info')
-  t.regex(t.context.captured, /INFO\s\d+\s"log.info"/)
+
+  let data = parse(t.context.captured)
+
+  t.is(data.type, 'INFO')
+  t.is(data.message, 'log.info')
+  t.is(data.data, null)
 })
 
 test('log.info data is an object', (t) => {
   log.info('log.info', {test: true})
 
-  // Extract logged data
-  let data = /(\{.*\})/.exec(t.context.captured)
-  let json = JSON.parse(data[0])
+  let data = parse(t.context.captured)
 
-  // Test logged object is an object
-  t.is(json.test, true)
-
-  // Should not be wrapped in an array
-  // this covers the legacy case where log
-  // wrapped everything in an array
-  t.is(Array.isArray(json), false)
+  t.is(data.data.test, true)
 })
 
 test('log.debug follows message pattern', (t) => {
   log.debug('log.debug')
-  t.regex(t.context.captured, /DEBUG\s\d+\s"log.debug"/)
+
+  let data = parse(t.context.captured)
+
+  t.is(data.type, 'DEBUG')
+  t.is(data.message, 'log.debug')
+  t.is(data.data, null)
 })
 
 test('log.warn follows message pattern', (t) => {
   log.warn('log.warn')
-  t.regex(t.context.captured, /WARN\s\d+\s"log.warn"/)
+
+  let data = parse(t.context.captured)
+
+  t.is(data.type, 'WARN')
+  t.is(data.message, 'log.warn')
+  t.is(data.data, null)
 })
 
 test('log.error follows message pattern', (t) => {
   log.error('log.error')
-  t.regex(t.context.captured, /ERROR\s\d+\s"log.error"/)
+
+  let data = parse(t.context.captured)
+
+  t.is(data.type, 'ERROR')
+  t.is(data.message, 'log.error')
+  t.is(data.data, null)
 })


### PR DESCRIPTION
Function signatures and arguments are unchanged. Should not introduce any breaking changes to consumers.
- Refactored to use a factory function instead of dynamic function exports.
- Refactored log to be an object instead of a string
- Non production logging now defaults to logging whole objects.
- If `NODE_ENV=production` logs will be stringified. This way log aggregation receives single line logs.
- updated tests
